### PR TITLE
Add Xquik x-twitter-scraper skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 | Skill Name             | Description                                                                       | Source                                                           |
 | ---------------------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
 | **X to Markdown**      | 将 X (Twitter) 推文、Thread 或文章转换为带有 YAML Front Matter 的 Markdown 格式。 | [`baoyu-danger-x-to-markdown`](baoyu/baoyu-danger-x-to-markdown) |
+| **Xquik x-twitter-scraper** | 为 Agent 提供 X/Twitter 推文搜索、个人主页推文、粉丝导出、媒体下载、发推、回复、DM、webhooks、MCP 与 SDK 工作流。 | [`xquik-x-twitter-scraper`](通用%20Skills/xquik-x-twitter-scraper) |
 | **Markdown Formatter** | 自动格式化 Markdown 文档，优化排版、标题、列表及代码块样式。                      | [`baoyu-format-markdown`](baoyu/baoyu-format-markdown)           |
 
 ### 🛠️ 工具与实用程序 (Tools & Utilities)

--- a/通用 Skills/xquik-x-twitter-scraper/SKILL.md
+++ b/通用 Skills/xquik-x-twitter-scraper/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: xquik-x-twitter-scraper
+description: Use Xquik's public X/Twitter API skill for tweet search, profile tweets, follower export, media download, posting, replies, DMs, webhooks, MCP, and SDK workflows. Requires a Xquik API key and confirmation before write actions.
+---
+
+# Xquik x-twitter-scraper
+
+Xquik x-twitter-scraper helps coding agents work with X/Twitter data and automation through the public Xquik API.
+
+## Use Cases
+
+- Search tweets with keyword, account, hashtag, and advanced Twitter search workflows.
+- Get tweets from a profile, user timeline, replies, quotes, likes, and media.
+- Export followers, following, search results, media, replies, and mentions.
+- Send tweets, post replies, like, repost, follow, unfollow, and send DMs after explicit user approval.
+- Set up account monitors, signed webhooks, MCP tools, and official SDKs.
+
+## Requirements
+
+- Xquik API key in `XQUIK_API_KEY`.
+- Internet access to `https://xquik.com/api/v1` and `https://docs.xquik.com`.
+- User confirmation before write actions, billing actions, persistent monitors, or webhook delivery.
+
+## Resources
+
+- GitHub: https://github.com/Xquik-dev/x-twitter-scraper
+- Docs: https://docs.xquik.com
+- MCP: https://xquik.com/mcp
+- TypeScript SDK: https://github.com/Xquik-dev/x-twitter-scraper-typescript
+- Python SDK: https://github.com/Xquik-dev/x-twitter-scraper-python


### PR DESCRIPTION
Adds the Xquik x-twitter-scraper skill to the content and data processing section.

The skill points agents to the public Xquik API, docs, MCP endpoint, TypeScript SDK, and Python SDK for tweet search, profile tweets, follower export, media download, posting, replies, DMs, webhooks, and SDK workflows.

Validation:
- Ran git diff --check.
- Checked linked public resources for reachability.
